### PR TITLE
Allow configure extra mysqldump args.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ models:
         database: gitlab_production
         username: root
         password:
+        additional_options: --single-transaction --quick
       gitlab_redis:
         type: redis
         mode: sync

--- a/database/mysql.go
+++ b/database/mysql.go
@@ -2,11 +2,12 @@ package database
 
 import (
 	"fmt"
+	"path"
+	"strings"
+
 	"github.com/huacnlee/gobackup/config"
 	"github.com/huacnlee/gobackup/helper"
 	"github.com/huacnlee/gobackup/logger"
-	"path"
-	"strings"
 )
 
 // MySQL database
@@ -18,15 +19,16 @@ import (
 // username: root
 // password:
 type MySQL struct {
-	Name        string
-	host        string
-	port        string
-	database    string
-	username    string
-	password    string
-	dumpCommand string
-	dumpPath    string
-	model       config.ModelConfig
+	Name              string
+	host              string
+	port              string
+	database          string
+	username          string
+	password          string
+	dumpCommand       string
+	dumpPath          string
+	additionalOptions string
+	model             config.ModelConfig
 }
 
 func (ctx *MySQL) perform(model config.ModelConfig, dbCfg config.SubConfig) (err error) {
@@ -34,6 +36,7 @@ func (ctx *MySQL) perform(model config.ModelConfig, dbCfg config.SubConfig) (err
 	viper.SetDefault("host", "localhost")
 	viper.SetDefault("username", "root")
 	viper.SetDefault("port", 3306)
+	viper.SetDefault("additional_options", "")
 
 	ctx.Name = dbCfg.Name
 	ctx.host = viper.GetString("host")
@@ -41,6 +44,7 @@ func (ctx *MySQL) perform(model config.ModelConfig, dbCfg config.SubConfig) (err
 	ctx.database = viper.GetString("database")
 	ctx.username = viper.GetString("username")
 	ctx.password = viper.GetString("password")
+	ctx.additionalOptions = viper.GetString("additional_options")
 	ctx.model = model
 
 	if err = ctx.prepare(); err != nil {
@@ -72,6 +76,9 @@ func (ctx *MySQL) prepare() (err error) {
 	}
 	if len(ctx.password) > 0 {
 		dumpArgs = append(dumpArgs, "-p"+ctx.password)
+	}
+	if len(ctx.additionalOptions) > 0 {
+		dumpArgs = append(dumpArgs, ctx.additionalOptions)
 	}
 
 	dumpArgs = append(dumpArgs, ctx.database)

--- a/database/mysql_test.go
+++ b/database/mysql_test.go
@@ -3,8 +3,9 @@ package database
 import (
 	"github.com/huacnlee/gobackup/config"
 	// "github.com/spf13/viper"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMySQLPrepare(t *testing.T) {
@@ -23,6 +24,25 @@ func TestMySQLPrepare(t *testing.T) {
 
 	assert.Equal(t, mysql.dumpPath, "/foo/bar/mysql/mysql1")
 	assert.Equal(t, mysql.dumpCommand, "mysqldump --host 127.0.0.2 --port 6378 -paaaa dummy_test")
+}
+
+func TestMySQLPrepareWithAdditionalOptions(t *testing.T) {
+	mysql := &MySQL{
+		Name:              "mysql1",
+		database:          "dummy_test",
+		host:              "127.0.0.2",
+		port:              "6378",
+		password:          "aaaa",
+		additionalOptions: "--single-transaction --quick",
+		model: config.ModelConfig{
+			DumpPath: "/foo/bar",
+		},
+	}
+	err := mysql.prepare()
+	assert.NoError(t, err)
+
+	assert.Equal(t, mysql.dumpPath, "/foo/bar/mysql/mysql1")
+	assert.Equal(t, mysql.dumpCommand, "mysqldump --host 127.0.0.2 --port 6378 -paaaa --single-transaction --quick dummy_test")
 }
 
 func TestMySQLPerform(t *testing.T) {


### PR DESCRIPTION
If mysqldump is used on master database directly, the default command
arguments will lock the whole database during the backup. It is
recommended to perform the backup with following arguments:

    --single-transaction --quick