### PR TITLE
Update README: Add the config path for current directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ GLOBAL OPTIONS:
 
 GoBackup will seek config files in:
 
+- ./gobackup.yml
 - ~/.gobackup/gobackup.yml
 - /etc/gobackup/gobackup.yml
 


### PR DESCRIPTION
According to `config.go` (https://github.com/huacnlee/gobackup/blob/master/config/config.go#L64), the current path will be added to viper as well. It can have the highest priority.

We should document this.