### PR TITLE
Turn S3ForcePathStyle to true when using custom endpoint.

### DIFF
--- a/storage/s3.go
+++ b/storage/s3.go
@@ -35,6 +35,7 @@ func (ctx *S3) open() (err error) {
 	endpoint := ctx.viper.GetString("endpoint")
 	if len(endpoint) > 0 {
 		cfg.Endpoint = aws.String(endpoint)
+		cfg.S3ForcePathStyle = aws.Bool(true)
 	}
 	cfg.Credentials = credentials.NewStaticCredentials(
 		ctx.viper.GetString("access_key_id"),


### PR DESCRIPTION
Fix for #19 

When using custom endpoints (like using minio) set S3ForcePathStyle so the url doesn't get changed.