### PR TITLE
make working directory configurable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -67,6 +67,8 @@ func Init(configFile string) {
 		return
 	}
 
+	viper.SetDefault("workdir", path.Join(os.TempDir(), "gobackup"))
+
 	Exist = true
 	Models = []ModelConfig{}
 	for key := range viper.GetStringMap("models") {
@@ -76,7 +78,7 @@ func Init(configFile string) {
 
 func loadModel(key string) (model ModelConfig) {
 	model.Name = key
-	model.TempPath = path.Join(os.TempDir(), "gobackup", fmt.Sprintf("%d", time.Now().UnixNano()))
+	model.TempPath = path.Join(viper.GetString("workdir"), fmt.Sprintf("%d", time.Now().UnixNano()))
 	model.DumpPath = path.Join(model.TempPath, key)
 	model.Viper = viper.Sub("models." + key)
 


### PR DESCRIPTION
When dealing with larger files, it is not advisable to use _/tmp_ for intermediate storage. Often, _tmpfs_ is used and this may lead to out of memory conditions. Therefore, it is now possible to specify a different working directory in _gobackup.yaml_. If the key is not present, the application will fall back to the old behaviour.