### PR TITLE
fix default compress_with

### DIFF
--- a/compressor/base.go
+++ b/compressor/base.go
@@ -46,7 +46,8 @@ func Run(model config.ModelConfig) (archivePath string, err error) {
 	case "tar":
 		ctx = &Tar{Base: base}
 	default:
-		ctx = &Tar{}
+		ctx = &Tar{Base: base}
+		model.CompressWith.Type = "tar"
 	}
 
 	logger.Info("------------ Compressor -------------")


### PR DESCRIPTION
When there's no `compress_with` in the config, it would be failed.

### Before

```
2022/11/27 22:20:01 ------------ Compressor -------------
2022/11/27 22:20:01 => Compress |
2022/11/27 22:20:01 -> 2022.11.27.22.20.01.tar
2022/11/27 22:20:01 ------------ Compressor -------------
```

```
$ tar tvf /tmp/demo/2022.11.27.22.20.01.tar
$
```

### After

```
2022/11/27 22:22:38 ------------ Compressor -------------
2022/11/27 22:22:38 => Compress | tar
2022/11/27 22:22:38 -> /tmp/gobackup/1669616558298631736/2022.11.27.22.22.38.tar
2022/11/27 22:22:38 ------------ Compressor -------------
```

```
$ tar tvf /tmp/demo/2022.11.27.22.22.38.tar
drwxr-xr-x zach/zach         0 2022-11-27 22:22 demo/
drwxr-xr-x zach/zach         0 2022-11-27 22:22 demo/postgresql/
drwxr-xr-x zach/zach         0 2022-11-27 22:22 demo/postgresql/postgresql/
-rw-r--r-- zach/zach     11196 2022-11-27 22:22 demo/postgresql/postgresql/demo.sql
```