### PR TITLE
Fix cycler

### DIFF
--- a/storage/cycler.go
+++ b/storage/cycler.go
@@ -63,6 +63,7 @@ func (c *Cycler) run(model string, fileKey string, keep int, deletePackage func(
 		}
 
 		err := deletePackage(pkg.FileKey)
+		logger.Info("Removed", pkg.FileKey)
 		if err != nil {
 			logger.Warn("remove failed: ", err)
 		}

--- a/storage/cycler.go
+++ b/storage/cycler.go
@@ -74,7 +74,7 @@ func (c *Cycler) load(cyclerFileName string) {
 
 	// write example JSON if not exist
 	if !helper.IsExistsPath(cyclerFileName) {
-		ioutil.WriteFile(cyclerFileName, []byte("[{}]"), os.ModePerm)
+		ioutil.WriteFile(cyclerFileName, []byte("[]"), os.ModePerm)
 	}
 
 	f, err := ioutil.ReadFile(cyclerFileName)


### PR DESCRIPTION
Currently an empty `file_key` will be written at first time which will cause cycler failure in the future.

Test with `keep: 2` in `local` storage.

### Before

#### run first time

```
2022/11/27 22:36:32 ------------- Storage --------------
2022/11/27 22:36:32 => Storage | local
2022/11/27 22:36:32 Store successed /tmp/demo
2022/11/27 22:36:32 ------------- Storage --------------
```

```
$ cat ~/.gobackup/cycler/demo.json
[{"file_key":"","created_at":"0001-01-01T00:00:00Z"},{"file_key":"2022.11.27.22.36.32.tar","created_at":"2022-11-27T22:36:32.975506421-08:00"}]
```

#### run second time

```
2022/11/27 22:36:51 ------------- Storage --------------
2022/11/27 22:36:51 => Storage | local
2022/11/27 22:36:51 Store successed /tmp/demo
2022/11/27 22:36:51 [debug] /usr/bin/rm /tmp/demo
2022/11/27 22:36:51 remove failed: /usr/bin/rm: cannot remove '/tmp/demo': Is a directory
```

```
$ cat ~/.gobackup/cycler/demo.json
[{"file_key":"2022.11.27.22.36.32.tar","created_at":"2022-11-27T22:36:32.975506421-08:00"},{"file_key":"2022.11.27.22.36.51.tar","created_at":"2022-11-27T22:36:51.863519463-08:00"}]
```

### After

#### run first time

```
2022/11/27 22:40:12 ------------- Storage --------------
2022/11/27 22:40:12 => Storage | local
2022/11/27 22:40:12 Store successed /tmp/demo
2022/11/27 22:40:12 ------------- Storage --------------
```

```
$ cat ~/.gobackup/cycler/demo.json
[{"file_key":"2022.11.27.22.40.12.tar","created_at":"2022-11-27T22:40:12.737104848-08:00"}]
```

#### run second time

```
2022/11/27 22:40:20 ------------- Storage --------------
2022/11/27 22:40:20 => Storage | local
2022/11/27 22:40:20 Store successed /tmp/demo
2022/11/27 22:40:20 ------------- Storage --------------
```

```
$ cat ~/.gobackup/cycler/demo.json
[{"file_key":"2022.11.27.22.40.12.tar","created_at":"2022-11-27T22:40:12.737104848-08:00"},{"file_key":"2022.11.27.22.40.20.tar","created_at":"2022-11-27T22:40:20.623696929-08:00
```

#### run third time

```
2022/11/27 22:40:30 ------------- Storage --------------
2022/11/27 22:40:30 => Storage | local
2022/11/27 22:40:30 Store successed /tmp/demo
2022/11/27 22:40:30 Removed 2022.11.27.22.40.12.tar
2022/11/27 22:40:30 ------------- Storage --------------
```