### PR TITLE
Resolves #47: use pigz when available

### DIFF
--- a/compressor/tgz.go
+++ b/compressor/tgz.go
@@ -32,9 +32,9 @@ func (ctx *Tgz) options() (opts []string) {
 	if helper.IsGnuTar {
 		opts = append(opts, "--ignore-failed-read")
 	}
-	_, err := exec.LookPath("pigz")
+	path, err := exec.LookPath("pigz")
 	if err == nil {
-		opts = append(opts, "-I", "pigz", "-cf")
+		opts = append(opts, "-I", path, "-cf")
 	} else {
 		opts = append(opts, "-zcf")
 	}

--- a/compressor/tgz.go
+++ b/compressor/tgz.go
@@ -1,6 +1,8 @@
 package compressor
 
 import (
+	"os/exec"
+
 	"github.com/huacnlee/gobackup/helper"
 )
 
@@ -30,7 +32,12 @@ func (ctx *Tgz) options() (opts []string) {
 	if helper.IsGnuTar {
 		opts = append(opts, "--ignore-failed-read")
 	}
-	opts = append(opts, "-zcf")
+	_, err := exec.LookPath("pigz")
+	if err == nil {
+		opts = append(opts, "-I", "pigz", "-cf")
+	} else {
+		opts = append(opts, "-zcf")
+	}
 
 	return
 }

--- a/compressor/tgz.go
+++ b/compressor/tgz.go
@@ -34,7 +34,7 @@ func (ctx *Tgz) options() (opts []string) {
 	}
 	path, err := exec.LookPath("pigz")
 	if err == nil {
-		opts = append(opts, "-I", path, "-cf")
+		opts = append(opts, "--use-compress-program", path, "-cf")
 	} else {
 		opts = append(opts, "-zcf")
 	}


### PR DESCRIPTION
### Before

```
2022/11/28 09:23:42 ------------ Compressor -------------
2022/11/28 09:23:42 => Compress | tgz
2022/11/28 09:23:54 -> /tmp/gobackup/1669627419533331673/2022.11.28.09.23.42.tar.gz
2022/11/28 09:23:54 ------------ Compressor -------------
```

12s

### After

```
2022/11/28 09:22:48 ------------ Compressor -------------
2022/11/28 09:22:48 => Compress | tgz
2022/11/28 09:22:52 -> /tmp/gobackup/1669627365452380531/2022.11.28.09.22.48.tar.gz
2022/11/28 09:22:52 ------------ Compressor -------------
```

4s

```
# ls -hl
total 221M
-rw-r--r-- 1 root root 111M Nov 28 09:22 2022.11.28.09.22.48.tar.gz
-rw-r--r-- 1 root root 111M Nov 28 09:23 2022.11.28.09.23.42.tar.gz
# nproc
4
```