### PR TITLE
Resolves #63: do not set default username in mongodb

### DIFF
--- a/database/mongodb.go
+++ b/database/mongodb.go
@@ -2,9 +2,10 @@ package database
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/huacnlee/gobackup/helper"
 	"github.com/huacnlee/gobackup/logger"
-	"strings"
 )
 
 // MongoDB database
@@ -36,7 +37,6 @@ func (ctx *MongoDB) perform() (err error) {
 	viper := ctx.viper
 	viper.SetDefault("oplog", false)
 	viper.SetDefault("host", "127.0.0.1")
-	viper.SetDefault("username", "root")
 	viper.SetDefault("port", 27017)
 
 	ctx.host = viper.GetString("host")


### PR DESCRIPTION
### Before

```
2022/11/28 03:12:21 ------------- Databases -------------
2022/11/28 03:12:21 => database | mongodb : mongodb
2022/11/28 03:12:21 mongodump: mongodump --db=test --username=root --host=127.0.0.1 --port=27017  --out=/tmp/gobackup/1669633941145249568/demo/mongodb/mongodb
2022/11/28 03:12:21 [debug] /usr/bin/mongodump --db=test --username=root --host=127.0.0.1 --port=27017 --out=/tmp/gobackup/1669633941145249568/demo/mongodb/mongodb
2022/11/28 03:12:21 -> Dump error: 2022-11-28T03:12:21.155-0800 reading password from standard input
Enter password for mongo user:
2022-11-28T03:12:21.162-0800    Failed: can't create session: could not connect to server: connection() error occurred during connection handshake: auth error: sasl conversation error: unable to authenticate using mechanism "SCRAM-SHA-1": (AuthenticationFailed) Authentication failed.
```

### After

```
2022/11/28 03:12:49 ------------- Databases -------------
2022/11/28 03:12:49 => database | mongodb : mongodb
2022/11/28 03:12:49 mongodump: mongodump --db=test  --host=127.0.0.1 --port=27017  --out=/tmp/gobackup/1669633969626609970/demo/mongodb/mongodb
2022/11/28 03:12:49
2022/11/28 03:12:49 dump path: /tmp/gobackup/1669633969626609970/demo/mongodb/mongodb
2022/11/28 03:12:49
2022/11/28 03:12:49 ------------- Databases -------------
```