### PR TITLE
Resolves #64: set CGO_ENABLED=0 in build

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -1,5 +1,7 @@
 builds:
   - binary: gobackup
+    env:
+      - CGO_ENABLED=0
     ldflags: -s -w -X main.version={{.Version}}
     goos:
       - darwin


### PR DESCRIPTION
### Before

```shell
/ # docker run --rm -it alpine sh
/ # apk add curl bash
fetch https://dl-cdn.alpinelinux.org/alpine/v3.17/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.17/community/x86_64/APKINDEX.tar.gz
(1/9) Installing ncurses-terminfo-base (6.3_p20221119-r0)
(2/9) Installing ncurses-libs (6.3_p20221119-r0)
(3/9) Installing readline (8.2.0-r0)
(4/9) Installing bash (5.2.9-r0)
Executing bash-5.2.9-r0.post-install
(5/9) Installing ca-certificates (20220614-r2)
(6/9) Installing brotli-libs (1.0.9-r9)
(7/9) Installing nghttp2-libs (1.51.0-r0)
(8/9) Installing libcurl (7.86.0-r1)
(9/9) Installing curl (7.86.0-r1)
Executing busybox-1.35.0-r29.trigger
Executing ca-certificates-20220614-r2.trigger
OK: 12 MiB in 24 packages
/ # curl -sSL https://git.io/gobackup | bash
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 4639k  100 4639k    0     0  9894k      0 --:--:-- --:--:-- --:--:-- 9894k
/ # gobackup -v
sh: gobackup: not found
/ # /usr/local/bin/gobackup -v
sh: /usr/local/bin/gobackup: not found
```

### Built with `CGO_ENABLED=0`

```shell
/ # /gobackup -v
gobackup version master
```