### PR TITLE
Resolves #29: add socket config in MySQL and Redis

### DIFF
--- a/database/mysql.go
+++ b/database/mysql.go
@@ -2,10 +2,11 @@ package database
 
 import (
 	"fmt"
-	"github.com/huacnlee/gobackup/helper"
-	"github.com/huacnlee/gobackup/logger"
 	"path"
 	"strings"
+
+	"github.com/huacnlee/gobackup/helper"
+	"github.com/huacnlee/gobackup/logger"
 )
 
 // MySQL database
@@ -13,6 +14,7 @@ import (
 // type: mysql
 // host: 127.0.0.1
 // port: 3306
+// socket:
 // database:
 // username: root
 // password:
@@ -21,6 +23,7 @@ type MySQL struct {
 	Base
 	host              string
 	port              string
+	socket            string
 	database          string
 	username          string
 	password          string
@@ -35,6 +38,7 @@ func (ctx *MySQL) perform() (err error) {
 
 	ctx.host = viper.GetString("host")
 	ctx.port = viper.GetString("port")
+	ctx.socket = viper.GetString("socket")
 	ctx.database = viper.GetString("database")
 	ctx.username = viper.GetString("username")
 	ctx.password = viper.GetString("password")
@@ -48,6 +52,12 @@ func (ctx *MySQL) perform() (err error) {
 		return fmt.Errorf("mysql database config is required")
 	}
 
+	// socket
+	if len(ctx.socket) != 0 {
+		ctx.host = ""
+		ctx.port = ""
+	}
+
 	err = ctx.dump()
 	return
 }
@@ -59,6 +69,9 @@ func (ctx *MySQL) dumpArgs() []string {
 	}
 	if len(ctx.port) > 0 {
 		dumpArgs = append(dumpArgs, "--port", ctx.port)
+	}
+	if len(ctx.socket) > 0 {
+		dumpArgs = append(dumpArgs, "--socket", ctx.socket)
 	}
 	if len(ctx.username) > 0 {
 		dumpArgs = append(dumpArgs, "-u", ctx.username)

--- a/database/postgresql.go
+++ b/database/postgresql.go
@@ -2,11 +2,13 @@ package database
 
 import (
 	"fmt"
-	"github.com/huacnlee/gobackup/helper"
-	"github.com/huacnlee/gobackup/logger"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
+
+	"github.com/huacnlee/gobackup/helper"
+	"github.com/huacnlee/gobackup/logger"
 )
 
 // PostgreSQL database
@@ -14,6 +16,7 @@ import (
 // type: postgresql
 // host: localhost
 // port: 5432
+// socket:
 // database: test
 // username:
 // password:
@@ -21,6 +24,7 @@ type PostgreSQL struct {
 	Base
 	host        string
 	port        string
+	socket      string
 	database    string
 	username    string
 	password    string
@@ -36,10 +40,17 @@ func (ctx PostgreSQL) perform() (err error) {
 
 	ctx.host = viper.GetString("host")
 	ctx.port = viper.GetString("port")
+	ctx.socket = viper.GetString("socket")
 	ctx.database = viper.GetString("database")
 	ctx.username = viper.GetString("username")
 	ctx.password = viper.GetString("password")
 	ctx.args = viper.GetString("args")
+
+	// socket
+	if len(ctx.socket) != 0 {
+		ctx.host = ""
+		ctx.port = ""
+	}
 
 	if err = ctx.prepare(); err != nil {
 		return
@@ -60,6 +71,11 @@ func (ctx *PostgreSQL) prepare() (err error) {
 	}
 	if len(ctx.port) > 0 {
 		dumpArgs = append(dumpArgs, "--port="+ctx.port)
+	}
+	if len(ctx.socket) > 0 {
+		host := filepath.Dir(ctx.socket)
+		port := strings.TrimPrefix(filepath.Ext(ctx.socket), ".")
+		dumpArgs = append(dumpArgs, "--host="+host, "--port="+port)
 	}
 	if len(ctx.username) > 0 {
 		dumpArgs = append(dumpArgs, "--username="+ctx.username)

--- a/database/redis.go
+++ b/database/redis.go
@@ -2,11 +2,12 @@ package database
 
 import (
 	"fmt"
-	"github.com/huacnlee/gobackup/helper"
-	"github.com/huacnlee/gobackup/logger"
 	"path"
 	"regexp"
 	"strings"
+
+	"github.com/huacnlee/gobackup/helper"
+	"github.com/huacnlee/gobackup/logger"
 )
 
 type redisMode int
@@ -23,12 +24,14 @@ const (
 // invoke_save: true
 // host: 192.168.1.2
 // port: 6379
+// socket:
 // password:
 // rdb_path: /var/db/redis/dump.rdb
 type Redis struct {
 	Base
 	host       string
 	port       string
+	socket     string
 	password   string
 	mode       redisMode
 	invokeSave bool
@@ -50,9 +53,16 @@ func (ctx *Redis) perform() (err error) {
 
 	ctx.host = viper.GetString("host")
 	ctx.port = viper.GetString("port")
+	ctx.socket = viper.GetString("socket")
 	ctx.password = viper.GetString("password")
 	ctx.rdbPath = viper.GetString("rdb_path")
 	ctx.invokeSave = viper.GetBool("invoke_save")
+
+	// socket
+	if len(ctx.socket) != 0 {
+		ctx.host = ""
+		ctx.port = ""
+	}
 
 	if viper.GetString("mode") == "sync" {
 		ctx.mode = redisModeSync
@@ -93,6 +103,9 @@ func (ctx *Redis) prepare() error {
 	}
 	if len(ctx.port) > 0 {
 		args = append(args, "-p "+ctx.port)
+	}
+	if len(ctx.socket) > 0 {
+		args = append(args, "-s", ctx.socket)
 	}
 	if len(ctx.password) > 0 {
 		args = append(args, `-a `+ctx.password)


### PR DESCRIPTION
## MySQL

When socket is enabled in mysqld:

### with `host` and `port`

```
2022/11/29 00:49:26 ------------- Databases -------------
2022/11/29 00:49:26 => database | mysql : mysql
2022/11/29 00:49:26 -> Dumping MySQL...
2022/11/29 00:49:26 [debug] /usr/bin/mysqldump --host localhost --port 3306 -u root -p123456 test --result-file=/tmp/gobackup/1669711766368415420/demo/mysql/mysql/test.sql
2022/11/29 00:49:26 -> Dump error: WARNING: Forcing protocol to  TCP  due to option specification. Please explicitly state intended protocol.
mysqldump: Got error: 2002: "Can't connect to server on 'localhost' (111)" when trying to connect
```

###  with `socket`

```
2022/11/29 00:50:37 ------------- Databases -------------
2022/11/29 00:50:37 => database | mysql : mysql
2022/11/29 00:50:37 -> Dumping MySQL...
2022/11/29 00:50:37 dumpArgs: [--socket /run/mysqld/mysqld.sock -u root -p123456 test --result-file=/tmp/gobackup/1669711837877949700/demo/mysql/mysql/test.sql]
2022/11/29 00:50:37 dump path: /tmp/gobackup/1669711837877949700/demo/mysql/mysql
2022/11/29 00:50:37
2022/11/29 00:50:37 ------------- Databases -------------
```

## Redis

### with `socket`

```
2022/11/29 01:31:36 ------------- Databases -------------
2022/11/29 01:31:36 => database | redis : redis
2022/11/29 01:31:36 args: [redis-cli -s /run/redis/redis.sock]
2022/11/29 01:31:36 -> Invoke save...
2022/11/29 01:31:36 Perform redis-cli save...
2022/11/29 01:31:36 Syncing redis dump to /tmp/gobackup/1669714296849196980/demo/redis/redis/dump.rdb
2022/11/29 01:31:41
2022/11/29 01:31:41 ------------- Databases -------------
```