### PR TITLE
Rewrite install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ Use `tar` command to archive many file or path into a `.tar` file.
 
 ## Install (macOS / Linux)
 
-```bash
-$ curl -sSL https://git.io/gobackup | bash
+```shell
+curl -sSL https://git.io/gobackup | sh
 ```
 
 after that, you will get `/usr/local/bin/gobackup` command.

--- a/config/config.go
+++ b/config/config.go
@@ -63,7 +63,7 @@ func Init(configFile string) {
 
 	err := viper.ReadInConfig()
 	if err != nil {
-		logger.Error("Load gobackup config faild", err)
+		logger.Error("Load gobackup config faild: ", err)
 		return
 	}
 

--- a/install
+++ b/install
@@ -1,29 +1,32 @@
+#!/usr/bin/env sh
+
+set -eu
+
 get_latest_release() {
-	curl --silent "https://api.github.com/repos/$repo/releases/latest" | # Get latest release from GitHub api
-		grep '"tag_name":' |                                            # Get tag line
-		sed -E 's/.*"([^"]+)".*/\1/'                                    # Pluck JSON value
-	}
+  repo="$1"
+	curl -sSL "https://api.github.com/repos/${repo}/releases/latest" | \
+    awk 'BEGIN{FS=": |,|\""}; /tag_name/{print $5}'
+}
 
-repo='huacnlee/gobackup'
-version=`get_latest_release`
-if [[ `uname` == 'Darwin' ]]; then
-   platform='darwin'
-else
-   platform='linux'
-fi
-if [[ `arch` == 'arm64' ]]; then
-	arch='arm64'
-else
-	arch='amd64'
-fi
-curl -SLo gobackup.tar.gz https://github.com/huacnlee/gobackup/releases/download/$version/gobackup-$platform-$arch.tar.gz
-tar zxf gobackup.tar.gz
+repo="huacnlee/gobackup"
+version="$(get_latest_release "${repo}")"  # v1.2.0
+platform="$(uname | tr "[A-Z]" "[a-z]")"  # Linux => linux
+arch="$(uname -m | sed 's/x86_64/amd64/')"  # x86_64 => amd64
+package="gobackup-${platform}-${arch}.tar.gz"
+package_url="https://github.com/${repo}/releases/download/${version}/${package}"
+bin="gobackup"
+dest_dir="/usr/local/bin"
+tmp_dir="$(mktemp -d)"
 
-if [[ `whoami` == 'root' ]]; then
-   mv gobackup /usr/local/bin/gobackup
-else
-   sudo mv gobackup /usr/local/bin/gobackup
-fi
-mkdir -p ~/.gobackup && touch ~/.gobackup/gobackup.yml
-rm gobackup.tar.gz
+trap "rm -r ${tmp_dir}" EXIT
 
+cd "${tmp_dir}"
+curl -sSL "${package_url}" | tar xzf -
+
+if test $(id -u) -eq 0; then
+   mv "${bin}" "${dest_dir}"
+else
+   sudo mv "${bin}" "${dest_dir}"
+fi
+
+mkdir -p ~/.gobackup


### PR DESCRIPTION
* use `uname -m` instead of `arch` since `arch` is not always available
* use temp dir as working dir
* add shebang back and use `sh` instead
* remove `touch ~/.gobackup/gobackup.yml` to make less confusing for new
user like #57

Touching an empty `~/.gobackup/gobackup.yml` may makes new user more confusing, it's better to just let user know config is not found.

### Test in Alpine

```shell
/ # sh -x install
+ set -eu
+ repo=huacnlee/gobackup
+ get_latest_release huacnlee/gobackup
+ repo=huacnlee/gobackup
+ curl -sSL https://api.github.com/repos/huacnlee/gobackup/releases/latest
+ awk 'BEGIN{FS=": |,|\""}; /tag_name/{print $5}'
+ version=v1.2.0
+ uname
+ tr '[A-Z]' '[a-z]'
+ platform=linux
+ uname -m
+ sed s/x86_64/amd64/
+ arch=amd64
+ package=gobackup-linux-amd64.tar.gz
+ package_url=https://github.com/huacnlee/gobackup/releases/download/v1.2.0/gobackup-linux-amd64.tar.gz
+ bin=gobackup
+ dest_dir=/usr/local/bin
+ mktemp -d
+ tmp_dir=/tmp/tmp.LMChpP
+ trap 'rm -r /tmp/tmp.LMChpP' EXIT
+ cd /tmp/tmp.LMChpP
+ curl -sSL https://github.com/huacnlee/gobackup/releases/download/v1.2.0/gobackup-linux-amd64.tar.gz
+ tar xzf -
+ id -u
+ test 0 -eq 0
+ mv gobackup /usr/local/bin
+ mkdir -p /root/.gobackup
+ rm -r /tmp/tmp.LMChpP
```

```shell
/ # gobackup -v
gobackup version 1.2.0
/ # gobackup perform
2022/11/30 06:25:59 Load gobackup config faildConfig File "gobackup" Not Found in "[/ /root/.gobackup /etc/gobackup]"
```