### PR TITLE
log timestamp at first

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -2,8 +2,10 @@ package logger
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"os"
+	"time"
 
 	"github.com/fatih/color"
 )
@@ -15,9 +17,18 @@ type Logger struct {
 
 var (
 	_logFlag     = log.Ldate | log.Ltime
-	_myLog       = log.New(os.Stdout, "", _logFlag)
+	_myLog       = log.New(&writer{os.Stdout, "2006/01/02 15:04:05"}, "", 0)
 	sharedLogger Logger
 )
+
+type writer struct {
+	io.Writer
+	timeFormat string
+}
+
+func (w writer) Write(b []byte) (n int, err error) {
+	return w.Writer.Write(append([]byte(time.Now().Format(w.timeFormat)+" "), b...))
+}
 
 func init() {
 	isTest := os.Getenv("GO_ENV") == "test"


### PR DESCRIPTION
After refactoring logger, it's a bit hard to track the timestamp since the tag prefix does not has the same indentation:

```
[Modal: demo] 2022/11/30 23:26:40 WorkDir: /tmp/gobackup/1669879600876214440/demo
[Database] 2022/11/30 23:26:40 => database | postgresql : postgresql
[PostgreSQL] 2022/11/30 23:26:40 -> Dumping PostgreSQL...
[PostgreSQL] 2022/11/30 23:26:41 dump path: /tmp/gobackup/1669879600876214440/demo/postgresql/postgresql/demo.sql
[Database] 2022/11/30 23:26:41
[Compressor] 2022/11/30 23:26:41 => Compress | tar
[Compressor] 2022/11/30 23:26:41 -> /tmp/gobackup/1669879600876214440/2022.11.30.23.26.41.tar
[Storage] 2022/11/30 23:26:41 => Storage | local
[Local] 2022/11/30 23:26:41 Store successed /tmp/demo
[Modal] 2022/11/30 23:26:41 Cleanup temp: /tmp/gobackup/1669879600876214440/
```

IMO it's better to logging timestamp at first.

```
2022/11/30 23:32:58 [Modal: demo] WorkDir: /tmp/gobackup/1669879978313387406/demo
2022/11/30 23:32:58 [Database] => database | postgresql : postgresql
2022/11/30 23:32:58 [PostgreSQL] -> Dumping PostgreSQL...
2022/11/30 23:32:58 [PostgreSQL] dump path: /tmp/gobackup/1669879978313387406/demo/postgresql/postgresql/demo.sql
2022/11/30 23:32:58 [Database]
2022/11/30 23:32:58 [Compressor] => Compress | tar
2022/11/30 23:32:58 [Compressor] -> /tmp/gobackup/1669879978313387406/2022.11.30.23.32.58.tar
2022/11/30 23:32:58 [Storage] => Storage | local
2022/11/30 23:32:58 [Local] Store successed /tmp/demo
2022/11/30 23:32:58 [Modal] Cleanup temp: /tmp/gobackup/1669879978313387406/
```