### PR TITLE
docker: replace busybox utils

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,29 @@
 FROM alpine:latest
 
-RUN apk update && apk add curl ca-certificates \
-  postgresql-client mysql-client redis mongodb-tools pigz openssl && \
-  rm -rf /var/cache/apk/*
+RUN apk add \
+      curl \
+      ca-certificates \
+      openssl \
+      postgresql-client \
+      mysql-client \
+      redis \
+      mongodb-tools \
+      # replace busybox utils
+      tar \
+      gzip \
+      pigz \
+      bzip2 \
+      # there is no pbzip2 yet
+      lzip \
+      xz-dev \
+      lzop \
+      xz \
+      # pixz is in edge atm
+      zstd \
+      && \
+    rm -rf /var/cache/apk/*
 
-WORKDIR /
-ADD install /install 
-RUN /install 
+ADD install /install
+RUN /install && rm /install
+
 CMD ["/usr/local/bin/gobackup"]


### PR DESCRIPTION
Builtin commands in BusyBox are not good as their replacements.